### PR TITLE
39 fix keyboard input

### DIFF
--- a/StateManager.py
+++ b/StateManager.py
@@ -41,12 +41,13 @@ class StateManager:
 	def __init__(self):
 		self.stateSem = BoundedSemaphore()
 		self.subscriberMap = dict() # maps message names to
-		self.downlinks = []
+		self.subscribers = []
 
 	def terminateState(self):
-		for queue in self.downlinks:
-			queue.put({"quit":"True"})
-		self.downlinks = []
+		for subscriber in self.subscribers:
+			subscriber.downlink.put({"quit":"True"})
+			# subscriber.cleanup()
+		self.subscribers = []
 
 	def getUplink(self):
 		uplink = Queue()
@@ -62,8 +63,8 @@ class StateManager:
 				self.subscriberMap[key] = list()
 			if process.downlink not in self.subscriberMap[key]:
 				self.subscriberMap[key].append(process.downlink)
-			if process.downlink not in self.downlinks:
-				self.downlinks.append(process.downlink)
+			if process not in self.subscribers:
+				self.subscribers.append(process)
 
 	def dumpSubscribers(self):
 		out = ""

--- a/roverprocess/ExampleServer.py
+++ b/roverprocess/ExampleServer.py
@@ -29,8 +29,11 @@ class ExampleServer(RoverServer):
     # NEVER USE "while True"; USE "while not self.quit".
     def workerFunction(self, **kwargs):
         while not self.quit:
-            print("Testing server threading " + str(kwargs["name"]))
-            time.sleep(2)
+            try:
+                print("Testing server threading " + str(kwargs["name"]))
+                time.sleep(1)
+            except KeyboardInterrupt:
+                self.quit = True
         print(str(kwargs["name"]) + " done")
 
     # regular RoverProcess stuff

--- a/roverprocess/RoverProcess.py
+++ b/roverprocess/RoverProcess.py
@@ -70,7 +70,10 @@ class RoverProcess(Process):
 		pass
 
 	def loop(self):
-		pass
+		try:
+			time.sleep(1)
+		except KeyboardInterrupt:
+			pass
 
 	def messageTrigger(self, message):
 		pass
@@ -83,10 +86,13 @@ class RoverProcess(Process):
 		self.uplink.put({key:value})
 
 	def cleanup(self):
-		if self.receiver != threading.current_thread():
-			print(self.__class__.__name__ + " shutting down")
-			self.receiver.quit = True
-			self.receiver.join(0.01)  # receiver is blocked by call to queue.get()
-		else: # cleanup was called from a message: cannot join current_thread
-			self.quit = True
+		try:
+			if self.receiver != threading.current_thread():
+				print(self.__class__.__name__ + " shutting down")
+				self.receiver.quit = True
+				self.receiver.join(0.01)  # receiver is blocked by call to queue.get()
+			else: # cleanup was called from a message: cannot join current_thread
+				self.quit = True
+		except KeyboardInterrupt:
+			pass
 

--- a/roverprocess/RoverProcess.py
+++ b/roverprocess/RoverProcess.py
@@ -57,7 +57,10 @@ class RoverProcess(Process):
 				try:
 					self.loop()
 				except KeyboardInterrupt:
-					pass
+					self.quit = True
+			self.cleanup()
+		except KeyboardInterrupt:
+			self.quit = True
 			self.cleanup()
 		except:
 			self.cleanup()
@@ -83,7 +86,7 @@ class RoverProcess(Process):
 		if self.receiver != threading.current_thread():
 			print(self.__class__.__name__ + " shutting down")
 			self.receiver.quit = True
-			self.receiver.join(0.25)  # receiver is blocked by call to queue.get()
+			self.receiver.join(0.01)  # receiver is blocked by call to queue.get()
 		else: # cleanup was called from a message: cannot join current_thread
 			self.quit = True
 

--- a/roverprocess/RoverServer.py
+++ b/roverprocess/RoverServer.py
@@ -27,7 +27,10 @@ class RoverServer(RoverProcess):
 			self.daemon = True
 
 		def run(self):
-			self.function(**self.kwargs)
+			try:
+				self.function(**self.kwargs)
+			except KeyboardInterrupt:
+				pass
 
 	def __init__(self, **kwargs):
 		RoverProcess.__init__(self, manager=kwargs["manager"])
@@ -42,8 +45,8 @@ class RoverServer(RoverProcess):
 		RoverProcess.cleanup(self)
 		self.quit = True
 		for thread in self.workers:
-			# print(thread)
-			# if thread.is_alive():
-				#force kill thread
-			thread.join(0.25)
+			try:
+				thread.join(0.25)
+			except KeyboardInterrupt:
+				pass
 

--- a/roverprocess/RoverServer.py
+++ b/roverprocess/RoverServer.py
@@ -46,7 +46,7 @@ class RoverServer(RoverProcess):
 		self.quit = True
 		for thread in self.workers:
 			try:
-				thread.join(0.25)
+				thread.join(0.1)
 			except KeyboardInterrupt:
 				pass
 


### PR DESCRIPTION
Fixed ugly crash when the some threads shut down. Rappidly pressing Ctrl-C will still cause a KeyboardInterupt exception, but I think we always used to have this problem. If anyone can figure out how to fix this before this is merged that would be cool...
