### PR TITLE
Added basic testing framework.

### DIFF
--- a/roverprocess/ExampleProcess.py
+++ b/roverprocess/ExampleProcess.py
@@ -28,7 +28,7 @@ class ExampleProcess(RoverProcess):
 	#	so that the StateManager knows who gets what message.
 	# Just put the name of the message in the relevant list.
 	def getSubscribed(self):
-		return ["heartbeat"]
+		return ["heartbeat", "respondTrue"]
 
 	# This is run once to set up anything you need.
 	# 	Hint: use the self object to store variables global to this process.
@@ -66,5 +66,11 @@ class ExampleProcess(RoverProcess):
 	# not the dictionary that contains multiple keys like in messageTrigger.
 	def on_heartbeat(self, message):
 		print("From callback got: " + str(messsage))
+
+	# This method demonstrates the testing framework. if test_ExampleProcess
+	# is running, it will send the "respondTrue" message with a value of False
+	# This module must respond True to pass the test
+	def on_respondTrue(self, message):
+		self.publish("response", not message)
 
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,93 @@
+# Copyright 2016 University of Saskatchewan Space Design Team Licensed under the
+# Educational Community License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may
+# obtain a copy of the License at
+#
+# https://opensource.org/licenses/ecl2.php
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import os
+import sys
+sys.dont_write_bytecode = True #prevent generation of .pyc files on imports
+import time
+import inspect # for dynamic imports
+import importlib #for dynamic imports
+from StateManager import StateManager
+
+# Check for hardware and load required modules
+# Add the class name of a module to modulesLis to enable it
+if(os.name == "nt"): # Windows test
+	modulesList = []
+
+elif(os.uname()[4] != "armv6l"): # Regular Linux/OSX test
+	from signal import signal, SIGPIPE, SIG_DFL
+	signal(SIGPIPE, SIG_DFL)
+	modulesList = ["ExampleProcess"]
+
+else: # Rover! :D
+	print("Detected Rover hardware! Full config mode\n")
+	from signal import signal, SIGPIPE, SIG_DFL
+	signal(SIGPIPE, SIG_DFL)
+	modulesList = []
+
+print("Enabled modules:")
+print(modulesList)
+
+testmodules = ["test_"+ module for module in modulesList]
+
+# Dynamically import all modules in the modulesList
+modules = []
+for name in modulesList:
+	try:
+		modules.append(importlib.import_module("roverprocess." + name))
+		modules.append(importlib.import_module("testprocess." + "test_"+ name))
+	except (ImportError):
+		print("\nERROR: Could not import " + name)
+		raise
+
+# module_classes is a list of lists where each list
+# contains tuples for every class in the module, and each
+# tuple contains a class name and a class object
+module_classes = [inspect.getmembers(module, inspect.isclass) for module in modules]
+
+# rover_classes is a list of classes to be instantiated.
+rover_classes = []
+for _list in module_classes:
+	for _tuple in _list:
+		if _tuple[0] in modulesList or _tuple[0] in testmodules:
+			rover_classes.append(_tuple[1])
+
+
+# build and run the system
+if __name__ == "__main__":
+
+	system = StateManager()
+	processes = []
+	print("\nBUILD: Registering process subsribers...\n")
+	for _class in rover_classes:
+		# if _class was enabled, instantiate it,
+		# and hook it up to the messaging system
+		if _class.__name__ in modulesList or _class.__name__ in testmodules:
+			instance = _class(manager=system)
+			for msg_key in instance.getSubscribed():
+				system.addSubscriber(msg_key, instance)
+			processes.append(instance)
+
+	# start everything
+	print("\nSTARTING: " + str([type(p).__name__ for p in processes]) + "\n")
+	for process in processes:
+		process.start()
+
+	# wait until ctrl-C or error
+	try:
+		while True:
+			time.sleep(60)
+	except KeyboardInterrupt:
+		print("\nSTOP: " + str([type(p).__name__ for p in processes]) + "\n")
+	finally:
+		system.terminateState()

--- a/testprocess/test_ExampleProcess.py
+++ b/testprocess/test_ExampleProcess.py
@@ -1,0 +1,42 @@
+# Copyright 2016 University of Saskatchewan Space Design Team Licensed under the
+# Educational Community License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may
+# obtain a copy of the License at
+#
+# https://opensource.org/licenses/ecl2.php
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from roverprocess.RoverProcess import RoverProcess
+
+import time
+
+
+class test_ExampleProcess(RoverProcess):
+	def getSubscribed(self):
+		return ["response"]
+
+	def setup(self, args):
+		self.num_out = 0
+		self.num_in = 0;
+
+	def loop(self):
+		while self.num_in != self.num_out:
+			time.sleep(0.05) # hacky way to syncronize with other process
+		#send a test message. subscribers sould return false
+		self.publish("respondTrue", False)
+		self.num_out += 1
+		time.sleep(1)
+
+	def on_response(self, message):
+		self.num_in += 1
+		if message:
+			print("Got good response")
+		else:
+			print("Receiver did not respond correctly")
+
+


### PR DESCRIPTION
This adds a way to test modules that are being developed. I found that I kept modifying the ExampleProcess to test messaging between new processes, which could cause merge conflicts in branches, and doesn't encourage continual testing beyond the first pull request.

List of changes:
- Add an alternative main bootsrap script "test.py" for running test modules. This keeps testing out of the regular roverprocess
- Added folder/module of "testprocesses". These are just RoverProcesses prefixed with "test_"
- Test for the Example process

Does the separate test.py program make sense, or should this be integrated into the main.py with some hard coded option or cli argument?