### PR TITLE
Changed rover mesages from  dictionary to named tuple

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ if(os.name == "nt"): # Windows test
 elif(os.uname()[4] != "armv6l"): # Regular Linux/OSX test
 	from signal import signal, SIGPIPE, SIG_DFL
 	signal(SIGPIPE, SIG_DFL)
-	modulesList = ["ExampleProcess", "DriveProcess", "USBServer", "WebServer"]
+	modulesList = ["ExampleProcess", "DriveProcess", "WebServer"]
 
 else: # Rover! :D
 	logging.info("Rover hardware detected. Full config mode") 

--- a/roverprocess/DriveProcess.py
+++ b/roverprocess/DriveProcess.py
@@ -27,8 +27,8 @@ class DriveProcess(RoverProcess):
 	# Function that grabs the x and y axis values in message, then formats the data
 	#  and prints the result to stdout.
 	# Returns the newly formated x and y axis values in a new list
-	def on_joystick1(self, message):
-		y_axis = message[1]
+	def on_joystick1(self, data):
+		y_axis = data[1]
 		y_axis = (y_axis * 40000/2) # half power for testing
 		if y_axis > 11000 or y_axis < -11000:
 			newMessage = y_axis
@@ -45,8 +45,8 @@ class DriveProcess(RoverProcess):
 	# Function that grabs the x and y axis values in message, then formats the data
 	#  and prints the result to stdout.
 	# Returns the newly formated x and y axis values in a new list
-	def on_joystick2(self, message):
-		y_axis = message[1]
+	def on_joystick2(self, data):
+		y_axis = data[1]
 		y_axis = (y_axis * 40000/2)
 		if y_axis > 11000 or y_axis < -11000:
 			newMessage = y_axis

--- a/roverprocess/ExampleProcess.py
+++ b/roverprocess/ExampleProcess.py
@@ -34,7 +34,7 @@ class ExampleProcess(RoverProcess):
 		# which is a list of messages it is currently subscribed to.
 		# You can read from this list, but please do not modify it,
 		# as that will mess things up. Use subscribe() and unsubscribe().
-		for key in ["Test", "respondTrue"]:
+		for key in ["Test", "respondTrue", "heartbeat"]:
 			self.subscribe(key)
 		self.someVariable = 42
 
@@ -51,8 +51,8 @@ class ExampleProcess(RoverProcess):
 	def messageTrigger(self, message):
 		RoverProcess.messageTrigger(self, message)
 
-		if "heartbeat" in message:
-			self.log("got: " + str(message["heartbeat"]))
+		if message.key == 'Test':
+			self.log("got: " + str(message.data))
 
 	# This runs once at the end when the program shuts down.
 	# You can use this to do something like stop motors, clean up open files, etc.
@@ -62,15 +62,14 @@ class ExampleProcess(RoverProcess):
 
 	# Whenever the "heartbeat" message is produced, the callback function "on_heartbeat"
 	# is called. This is an alternative to using large if/else structures in
-	# messageTrigger. In this function, message is the contents of the message,
-	# not the dictionary that contains multiple keys like in messageTrigger.
-	def on_heartbeat(self, message):
-		self.log("From callback got: " + str(messsage))
+	# messageTrigger.
+	def on_heartbeat(self, data):
+		self.log("From callback got: " + str(data))
 
 	# This method demonstrates the testing framework. If test_ExampleProcess
 	# is running, it will send the "respondTrue" message with a value of False
 	# This module must respond True to pass the test
-	def on_respondTrue(self, message):
-		self.publish("response", not message)
+	def on_respondTrue(self, data):
+		self.publish("response", not data)
 
 

--- a/testprocess/StateManagerTestProcess2.py
+++ b/testprocess/StateManagerTestProcess2.py
@@ -10,7 +10,7 @@ class StateManagerTestProcess2(RoverProcess):
 
 	def messageTrigger(self, message):
 
-		if "Test" in message:
-			self.log("Process 2 got: " + str(message["Test"]))
+		if message.key == 'Test':
+			self.log("Process 2 got: " + str(message.data))
 
 

--- a/testprocess/StateManagerTestProcess3.py
+++ b/testprocess/StateManagerTestProcess3.py
@@ -16,7 +16,7 @@ class StateManagerTestProcess3(RoverProcess):
 
 	def messageTrigger(self, message):
 
-		if "Test" in message:
-			self.log("Process 3 got: " + str(message["Test"]))
+		if message.key == 'Test':
+			self.log("Process 3 got: " + str(message.data))
 
 

--- a/testprocess/test_ExampleProcess.py
+++ b/testprocess/test_ExampleProcess.py
@@ -32,9 +32,9 @@ class test_ExampleProcess(RoverProcess):
 		self.num_out += 1
 		time.sleep(1)
 
-	def on_response(self, message):
+	def on_response(self, data):
 		self.num_in += 1
-		if message:
+		if data:
 			self.log("Got response", "DEBUG")
 		else:
 			self.log("Receiver did not respond correctly", "ERROR")


### PR DESCRIPTION
I thought that implementing rover messages as dictionaries was not optimal as a message only has one key and one data element. Finding what the message's key is is awkward, and makes things like message routers (like the USBServer) anoying to implement.
I changed messages to be a named tuple, which is in the standard python collections library and is like a regular tuple, but you can access the elements by name.

Example:
```RoverMessage = collections.namedtuple('RoverMessage', ['key', 'data']
 my_message = RoverMessage("TestKey", [1, 2, 3])
 my_message[0] == my_message.key # True
 my_message[1] == my_message.data # True
```
Note that you never have to create instances of RoverMessage. This is done by the RoverProcess class. You only have to make sure you access message elements properly in  message trigger methods.

List of changes:
- Added RoverMessage named tuple with fields 'key' and 'data'
- Updated core to use RoverMessages instead of dictionaries
- Updated ExampleProcess, DriveProcess, StateManager, and test processes. Other modules will be fixed as time goes on (If you wrote a process that receives messages, you should update it 😉 ).

